### PR TITLE
Rack 3 no longer required environments - WIP

### DIFF
--- a/lib/thin/env.rb
+++ b/lib/thin/env.rb
@@ -1,0 +1,33 @@
+
+module Thin
+  module Env
+    def self.with_defaults(env)
+      if ::Rack.release >= "3"
+        rack_env_class = Rack3
+      else
+        rack_env_class = Rack2
+      end
+
+      rack_env_class.env.merge(env)
+    end
+  end
+
+  private
+
+  class Rack2
+    def self.env
+      {
+        ::Thin::Request::RACK_VERSION      => ::Thin::VERSION::RACK,
+        ::Thin::Request::RACK_MULTITHREAD  => false,
+        ::Thin::Request::RACK_MULTIPROCESS => false,
+        ::Thin::Request::RACK_RUN_ONCE     => false
+      }
+    end
+  end
+
+  class Rack3
+    def self.env
+      {}
+    end
+  end
+end

--- a/lib/thin/request.rb
+++ b/lib/thin/request.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require_relative './env'
 
 module Thin
   # Raised when an incoming request is not valid
@@ -55,20 +56,14 @@ module Thin
       @data     = String.new
       @nparsed  = 0
       @body     = StringIO.new(INITIAL_BODY.dup)
-      @env      = {
+      @env      = Env.with_defaults({
         SERVER_SOFTWARE   => SERVER,
         SERVER_NAME       => LOCALHOST,
 
         # Rack stuff
         RACK_INPUT        => @body,
-
-        RACK_VERSION      => VERSION::RACK,
         RACK_ERRORS       => STDERR,
-
-        RACK_MULTITHREAD  => false,
-        RACK_MULTIPROCESS => false,
-        RACK_RUN_ONCE     => false
-      }
+      })
     end
 
     # Parse a chunk of data into the request environment


### PR DESCRIPTION
* when using Rack 3, don't add no longer required environments (rack.multithread/rack.multiprocess/rack.run_once/rack.version)